### PR TITLE
Trigger the event loop semaphore at the right time

### DIFF
--- a/qode/integration/node_integration.cc
+++ b/qode/integration/node_integration.cc
@@ -20,7 +20,7 @@ NodeIntegration::NodeIntegration()
 }
 
 constexpr uint64_t EVENT_BATCH_TIMEOUT_MS = 8;
-constexpr int EVENT_BATCH_SIZE = 64;
+constexpr int EVENT_BATCH_SIZE = 16;
 
 NodeIntegration::~NodeIntegration() {
   // Quit the embed thread.

--- a/qode/integration/node_integration_win.cc
+++ b/qode/integration/node_integration_win.cc
@@ -4,6 +4,7 @@
 
 #include "qode/integration/node_integration_win.h"
 #include "uv/src/uv-common.h"
+#include <stdio.h>
 
 // http://blogs.msdn.com/oldnewthing/archive/2004/10/25/247180.aspx
 extern "C" IMAGE_DOS_HEADER __ImageBase;
@@ -70,7 +71,11 @@ void NodeIntegrationWin::PostTask(const std::function<void()>& task) {
   ::EnterCriticalSection(&lock_);
   tasks_[++task_id_] = task;
   ::LeaveCriticalSection(&lock_);
-  ::PostMessage(message_window_, WM_USER, task_id_, 0L);
+  BOOL result = ::PostMessage(message_window_, WM_USER, task_id_, 0L);
+  if (result == 0) {
+    int lastError = ::GetLastError();
+    fprintf(stderr, "Qode: PostMessage() failed! LastError=%d\n", lastError);
+  }
 }
 
 void NodeIntegrationWin::OnTask(int id) {


### PR DESCRIPTION
This should prevent the hidden window on Windows from getting spammed,
and also prevent qode from entering this weird "slow down" state.

issue https://github.com/nodegui/qodejs/issues/4

It also contains some improvements to drastically increase the I/O throughput on Windows. Basically, triggering the main thread to go process nodejs events is expensive. The change is to call `uv_run()` multiple times instead of just once whenever we need to process nodejs events. When I/O is busy, calling multiple times will process more I/O events with less of the overhead and latency incurred by the two threads communicating with each other.

I have a little test program which times writing out the numbers 1 to 1000000 to a file one line at a time. Afterwards, it reads the file back in using 1KB chunks. The result are below are for Windows and Linux. They include plain nodejs, Qode without the extra event processing, and also Qode with different amounts of extra `uv_run()` calls.

Note: The amount of time processing a batch of events is capped at 8ms to prevent high I/O conditions from starving off the Qt event loop.

**Windows**

|                              | Write (ms)|Read (ms)|
|------------------------------|----------:|--------:|
|NodeJS only I/O               |     16,008|      108|
|Qode original                 |     56,154|      386|
|Qode + 64 extra uv_run() calls|     15,057|      104|
|Qode + 32 extra uv_run() calls|     16,980|      117|
|Qode + 16 extra uv_run() calls|     17,236|      120|
|Qode + 8 extra uv_run() calls |     26,556|      182|

**Linux**

|                              |Write MS|Read MS|
|------------------------------|-------:|------:|
|NodeJS only I/O               |  13,672|     77|
|Qode original                 |  25,832|    133|
|Qode + 64 extra uv_run() calls|  13,435|     75|
|Qode + 32 extra uv_run() calls|  15,048|     74|
|Qode + 16 extra uv_run() calls|  17,673|     70|
|Qode + 8 extra uv_run() calls |  21,237|     84|

Note: Different machines are used between Windows and Linux.

Around about 16 extra calls in a batch seems to be a good trade off for Windows and Linux. I assume that this also holds for macOS.
