### PR TITLE
add python 3.14 support to the `./config` file

### DIFF
--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
 command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
 command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
@@ -22,7 +23,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
+acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:


### PR DESCRIPTION
Added to `_` the following element: `command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"`

Added to `acceptable_pythons` the following tuple: `(3, 14)`

Qode.JS compiles successfully on Arch Linux with python 3.14.2.

The Node.JS project already supports python 3.14 in it's `./config` file.